### PR TITLE
Moving my account to the AWS Community

### DIFF
--- a/aws-community-builders.csv
+++ b/aws-community-builders.csv
@@ -16,7 +16,7 @@ udondan@frankfurt.social,true
 vattybear@awscommunity.social,true
 ervinszilagyi@awscommunity.social,true
 andreas@social.cloudonaut.io,true
-marcosluis2186@data-folks.masto.host,true
+@marcosluis2186@awscommunity.social,true
 eyalestrin@mastodon.online,true
 edmundcraske@hachyderm.io,true
 jbutz@mastodon.social,true


### PR DESCRIPTION
I just moved my Mastodon account to: @marcosluis2186@awscommunity.social